### PR TITLE
Use v2 link for godoc badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/github/v/release/MakeNowJust/heredoc)](https://github.com/MakeNowJust/heredoc/releases)
 [![Build Status](https://circleci.com/gh/MakeNowJust/heredoc.svg?style=svg)](https://circleci.com/gh/MakeNowJust/heredoc)
-[![GoDoc](https://godoc.org/github.com/MakeNowJusti/heredoc?status.svg)](https://godoc.org/github.com/MakeNowJust/heredoc)
+[![GoDoc](https://godoc.org/github.com/MakeNowJusti/heredoc/v2?status.svg)](https://godoc.org/github.com/MakeNowJust/heredoc/v2)
 
 ## About
 


### PR DESCRIPTION
This is not a very important change. But when I followed the link to godoc and then clicked a link to view the source code, I was confused when I was linked to the v1.0.0 source code. This makes sure users will be linked to the `/v2` documentation.